### PR TITLE
Fix missing score assignment in UCI go command

### DIFF
--- a/src/uci.py
+++ b/src/uci.py
@@ -102,11 +102,11 @@ def uci_loop(state):
                 mcts = MCTS(timeLimit=my_time)
                 best_move, score = mcts.search(state)
 
-            else:          
+            else:
                 # search placeholder for various time controls
                 mcts = MCTS(timeLimit=1000)
-                best_move = mcts.search(state)
-            
+                best_move, score = mcts.search(state)
+
             # return best move to the GUI
             send('info score cp %s' % score)
             send('bestmove %s' % best_move)


### PR DESCRIPTION
## Summary
- ensure both best move and score are returned when `go` is used without explicit time

## Testing
- `python -m py_compile src/uci.py`
- `python - <<'PY'
import os
os.chdir('src')
from state import State
from uci import send
from mcts import mcts as MCTS
state = State()
mcts_engine = MCTS(timeLimit=10)
move, score = mcts_engine.search(state)
send('info score cp %s' % score)
send('bestmove %s' % move)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad2e676df8832796b3ee98ee8f02ea