### PR TITLE
Ensure score returned from MCTS search in UCI loop

### DIFF
--- a/src/uci.py
+++ b/src/uci.py
@@ -102,12 +102,13 @@ def uci_loop(state):
                 mcts = MCTS(timeLimit=my_time)
                 best_move, score = mcts.search(state)
 
-            else:          
-                # search placeholder for various time controls
+            else:
+                # Fallback when no explicit time control is given; still
+                # retrieve both the best move and its evaluation score.
                 mcts = MCTS(timeLimit=1000)
-                best_move = mcts.search(state)
+                best_move, score = mcts.search(state)
             
-            # return best move to the GUI
+            # return best move along with evaluation score to the GUI
             send('info score cp %s' % score)
             send('bestmove %s' % best_move)
             


### PR DESCRIPTION
## Summary
- Capture both best move and evaluation score from `mcts.search` in the UCI loop
- Document fallback search path when no time control is provided
- Send evaluation score along with best move back to the GUI

## Testing
- `pytest`
- `python -m py_compile src/uci.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad2f9083648327b4ad49c2148091e3