### PR TITLE
Add self-play learning framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@ Python implementation of MCTS + NNUE chess engine (very basic)
 
 # LIVE CODING STREAMS
 [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/6ZxRgwwBkgU/0.jpg)](https://www.youtube.com/watch?v=6ZxRgwwBkgU&list=PLmN0neTso3Jx8FQSmq9Iab7q7zILYgKjt)
+
+## Self Learning
+
+A minimal self-play training loop is available in `src/self_learning.py`. It
+plays games against itself using MCTS and stores simple centipawn evaluations
+for encountered positions. Run it with:
+
+```bash
+python src/self_learning.py --games 10 --iterations 50
+```
+
+Learned values are persisted to `data/selfplay.json` and will be used to
+override NNUE evaluations on subsequent runs.

--- a/src/self_learning.py
+++ b/src/self_learning.py
@@ -1,0 +1,77 @@
+import argparse
+import json
+import os
+
+from state import State
+from mcts import mcts, nnue_policy
+
+
+class SelfLearner:
+    """Simple table-based learner storing centipawn evaluations by FEN."""
+
+    def __init__(self, alpha=0.1, path="data/selfplay.json"):
+        self.alpha = alpha
+        self.path = path
+        self.values = {}
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                try:
+                    self.values = json.load(f)
+                except json.JSONDecodeError:
+                    self.values = {}
+
+    def get_value(self, fen):
+        return self.values.get(fen)
+
+    def update(self, fens, result):
+        # convert result (1/0.5/0) to centipawns
+        target = (result - 0.5) * 20000
+        for fen in fens:
+            old = self.values.get(fen, 0.0)
+            new = old + self.alpha * (target - old)
+            self.values[fen] = new
+
+    def save(self):
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(self.values, f)
+
+
+def play_game(learner, iterations=50):
+    state = State()
+    searcher = mcts(iterationLimit=iterations,
+                    rolloutPolicy=lambda s: nnue_policy(s, learner))
+    fens = []
+    while not state.is_terminal():
+        fens.append(state.board.fen())
+        move, _ = searcher.search(state)
+        state = state.take_action(move)
+    fens.append(state.board.fen())
+
+    res = state.board.result()
+    if res == "1-0":
+        result = 1.0
+    elif res == "0-1":
+        result = 0.0
+    else:
+        result = 0.5
+    learner.update(fens, result)
+    learner.save()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Self-play training loop")
+    parser.add_argument("--games", type=int, default=10, help="number of games to play")
+    parser.add_argument("--iterations", type=int, default=50,
+                        help="MCTS iterations per move")
+    args = parser.parse_args()
+
+    learner = SelfLearner()
+    for i in range(args.games):
+        result = play_game(learner, iterations=args.iterations)
+        print(f"Game {i+1}: result {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add table-based self-learning module for self-play training
- integrate optional learned values into MCTS evaluation
- document self-play usage and ignore generated data

## Testing
- `pip install python-chess`
- `./src/chess.sh <<'EOF'
uci
isready
quit
EOF`
- `python src/self_learning.py --games 1 --iterations 5`


------
https://chatgpt.com/codex/tasks/task_e_68ad2e672c788327bcfdea9e65001c1b