### PR TITLE
Handle platform-specific NNUE library and add AlphaZero-style search

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ via `ctypes.WinDLL`. Make sure to use a 64-bit build if you are running a
 
 `src/alpha_zero.py` contains a minimal AlphaZero-inspired MCTS. It expects a
 network that returns a policy over legal moves and a value in [-1, 1] for a
-given position. A small PyTorch network supplies both policy and value heads:
+given position. A small PyTorch network supplies both policy and value heads.
+Positions are encoded as 17 planes for piece locations, side to move, and
+castling rights:
 
 ```bash
 python - <<'PY'

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ via `ctypes.WinDLL`. Make sure to use a 64-bit build if you are running a
 
 `src/alpha_zero.py` contains a minimal AlphaZero-inspired MCTS. It expects a
 network that returns a policy over legal moves and a value in [-1, 1] for a
-given position. A tiny trainable network using PyTorch now provides the value
-head while keeping a uniform policy for simplicity:
+given position. A small PyTorch network supplies both policy and value heads:
 
 ```bash
 python - <<'PY'
@@ -48,13 +47,15 @@ print(move)
 PY
 ```
 
-This demonstrates the PUCT-based MCTS loop.
+This demonstrates the PUCT-based MCTS loop using the network's policy and value
+predictions.
 
 ### Reinforcement learning
 
 `AlphaZeroTrainer` implements a very small self-play reinforcement learning
-loop that updates the value network from game outcomes. Running the module as a
-script performs one training step and prints the training loss:
+loop that updates the network on both value and policy targets derived from
+self-play. Running the module as a script performs one training step and prints
+the training loss:
 
 ```bash
 python src/alpha_zero.py

--- a/README.md
+++ b/README.md
@@ -16,3 +16,36 @@ python src/self_learning.py --games 10 --iterations 50
 
 Learned values are persisted to `data/selfplay.json` and will be used to
 override NNUE evaluations on subsequent runs.
+
+## NNUE Library
+
+The engine relies on a small C++ helper library for probing Stockfish NNUE
+networks. A prebuilt Linux version (`libnnueprobe.so`) is provided in `src/`.
+When running on other platforms the code now looks for `libnnueprobe.dll` on
+Windows or `libnnueprobe.dylib` on macOS. Ensure the appropriate library for
+your platform is available in the `src/` directory or update `src/mcts.py` to
+point to a compatible build. On Windows the file should be named
+`libnnueprobe.dll` and reside alongside the Python sources so it can be loaded
+via `ctypes.WinDLL`. Make sure to use a 64-bit build if you are running a
+64-bit version of Python.
+
+## AlphaZero-style search
+
+`src/alpha_zero.py` contains a minimal AlphaZero-inspired MCTS. It expects a
+network that returns a policy over legal moves and a value in [-1, 1] for a
+given position. A `DummyNetwork` using the NNUE evaluation for the value head
+and a uniform policy is provided as a placeholder:
+
+```bash
+python - <<'PY'
+from state import State
+from alpha_zero import AlphaZeroMCTS, DummyNetwork
+
+searcher = AlphaZeroMCTS(DummyNetwork(), n_simulations=10)
+move = searcher.search(State())
+print(move)
+PY
+```
+
+This demonstrates the PUCT-based MCTS loop and can be swapped out for a real
+policy/value network trained via self-play.

--- a/README.md
+++ b/README.md
@@ -33,19 +33,32 @@ via `ctypes.WinDLL`. Make sure to use a 64-bit build if you are running a
 
 `src/alpha_zero.py` contains a minimal AlphaZero-inspired MCTS. It expects a
 network that returns a policy over legal moves and a value in [-1, 1] for a
-given position. A `DummyNetwork` using the NNUE evaluation for the value head
-and a uniform policy is provided as a placeholder:
+given position. A tiny trainable network using PyTorch now provides the value
+head while keeping a uniform policy for simplicity:
 
 ```bash
 python - <<'PY'
 from state import State
-from alpha_zero import AlphaZeroMCTS, DummyNetwork
+from alpha_zero import AlphaZeroMCTS, TinyNetwork
 
-searcher = AlphaZeroMCTS(DummyNetwork(), n_simulations=10)
+net = TinyNetwork()
+searcher = AlphaZeroMCTS(net, n_simulations=10)
 move = searcher.search(State())
 print(move)
 PY
 ```
 
-This demonstrates the PUCT-based MCTS loop and can be swapped out for a real
-policy/value network trained via self-play.
+This demonstrates the PUCT-based MCTS loop.
+
+### Reinforcement learning
+
+`AlphaZeroTrainer` implements a very small self-play reinforcement learning
+loop that updates the value network from game outcomes. Running the module as a
+script performs one training step and prints the training loss:
+
+```bash
+python src/alpha_zero.py
+```
+
+This is intentionally lightweight and meant for experimentation rather than
+playing strength.

--- a/src/alpha_zero.py
+++ b/src/alpha_zero.py
@@ -1,0 +1,97 @@
+import math
+from typing import Dict, Tuple
+import chess
+
+from state import State
+from mcts import nnue  # reuse NNUE evaluation for value head
+
+def _uniform_policy(board: chess.Board) -> Dict[str, float]:
+    moves = list(board.legal_moves)
+    if not moves:
+        return {}
+    p = 1.0 / len(moves)
+    return {m.uci(): p for m in moves}
+
+class DummyNetwork:
+    """Simple placeholder network using NNUE for value and uniform policy.
+
+    This mimics the AlphaZero interface where ``predict`` returns a policy
+    distribution over legal moves and a value in [-1, 1]. The value is derived
+    from the NNUE centipawn evaluation and clamped to the required range.
+    """
+
+    def predict(self, state: State) -> Tuple[Dict[str, float], float]:
+        policy = _uniform_policy(state.board)
+        score = nnue.nnue_evaluate_fen(state.board.fen().encode("utf-8"))
+        value = max(min(score / 1000.0, 1), -1)
+        return policy, value
+
+class AZNode:
+    def __init__(self, state: State, parent=None, prior: float = 0.0):
+        self.state = state
+        self.parent = parent
+        self.prior = prior
+        self.children: Dict[str, "AZNode"] = {}
+        self.N = 0  # visit count
+        self.W = 0  # total value
+        self.Q = 0  # mean value
+        self.is_terminal = state.is_terminal()
+
+    def expand(self, policy: Dict[str, float]):
+        for action, prob in policy.items():
+            if action not in self.children:
+                next_state = self.state.take_action(action)
+                self.children[action] = AZNode(next_state, self, prob)
+
+    def select(self, c_puct: float):
+        return max(
+            self.children.items(),
+            key=lambda item: item[1].Q + c_puct * item[1].prior * math.sqrt(self.N) / (1 + item[1].N),
+        )
+
+class AlphaZeroMCTS:
+    def __init__(self, network: DummyNetwork, c_puct: float = 1.0, n_simulations: int = 50):
+        self.network = network
+        self.c_puct = c_puct
+        self.n_simulations = n_simulations
+
+    def search(self, state: State) -> str:
+        self.root = AZNode(state)
+        policy, value = self.network.predict(state)
+        self.root.expand(policy)
+        self.root.W += value
+        self.root.N += 1
+
+        for _ in range(self.n_simulations):
+            node = self.root
+            path = [node]
+            # Selection
+            while node.children:
+                action, node = node.select(self.c_puct)
+                path.append(node)
+            # Expansion
+            if not node.is_terminal:
+                policy, value = self.network.predict(node.state)
+                node.expand(policy)
+            else:
+                result = node.state.board.result()
+                if result == "1-0":
+                    value = 1
+                elif result == "0-1":
+                    value = -1
+                else:
+                    value = 0
+            # Backup
+            for n in reversed(path):
+                n.N += 1
+                n.W += value
+                n.Q = n.W / n.N
+                value = -value
+
+        best_action, _ = max(self.root.children.items(), key=lambda item: item[1].N)
+        return best_action
+
+if __name__ == "__main__":
+    searcher = AlphaZeroMCTS(DummyNetwork(), n_simulations=10)
+    move = searcher.search(State())
+    print("best move", move)

--- a/src/mcts.py
+++ b/src/mcts.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
-from ctypes import *
+import ctypes
+import sys
 import time
 import math
 import random
@@ -9,7 +10,28 @@ import os
 
 # load NNUE shared library and weights relative to this file
 BASE_DIR = os.path.dirname(__file__)
-nnue = cdll.LoadLibrary(os.path.join(BASE_DIR, "libnnueprobe.so"))
+
+# Determine the correct library extension for the current platform
+if sys.platform.startswith("win"):
+    lib_name = "libnnueprobe.dll"
+    loader = ctypes.WinDLL
+elif sys.platform == "darwin":
+    lib_name = "libnnueprobe.dylib"
+    loader = ctypes.CDLL
+else:
+    lib_name = "libnnueprobe.so"
+    loader = ctypes.CDLL
+
+lib_path = os.path.join(BASE_DIR, lib_name)
+
+try:
+    nnue = loader(lib_path)
+except OSError as e:
+    raise OSError(
+        f"Could not load NNUE library '{lib_name}': {e}. "
+        "Ensure the correct library for your platform is present in the src directory."
+    )
+
 nnue.nnue_init(os.path.join(BASE_DIR, "nn-c3ca321c51c9.nnue").encode("utf-8"))
 
 def randomPolicy(state):


### PR DESCRIPTION
## Summary
- Load the NNUE helper library with an OS-appropriate extension and provide clearer errors when missing
- Document required NNUE library files for different platforms
- Introduce an experimental AlphaZero-style MCTS module with a placeholder policy/value network
- Use WinDLL on Windows and document placement of the `.dll` helper library

## Testing
- `python src/engine.py <<'EOF'
uci
quit
EOF`
- `python src/alpha_zero.py`


------
https://chatgpt.com/codex/tasks/task_e_68adf148df90832794ccb9694ffdb51d